### PR TITLE
Add Missing Weapon Item Types and Death Tags

### DIFF
--- a/src/FortniteReplayReader/Models/Enums/ItemRarity.cs
+++ b/src/FortniteReplayReader/Models/Enums/ItemRarity.cs
@@ -12,6 +12,8 @@ namespace FortniteReplayReader.Models.Enums
         PrimalAssaultRifle, PrimalSmg, PrimalShotgun, PrimalRevolver, PrimalBow, StinkBow,
         FlameBow, MechBow, MechExplosiveBow, MetalBow,
         Recycler, Shark, Raptor, Wolf,
-        SlonePulseRifle, ReconScanner, RailGun, LlamaRoasterV3, KymeraRayGun, LeverShotgun
+        SlonePulseRifle, ReconScanner, RailGun, LlamaRoasterV3, KymeraRayGun, LeverShotgun,
+        TrackerPistol, ShockwaveBow, GrapplerBow, Fire, DubShotgun, EggLauncher, EnvironmentExplosion, EnvironmentExplosiveGas, Boat,
+        Lightsaber, E11BlasterRifle, BuildingProp, Ufo, Ability
     };
 }

--- a/src/FortniteReplayReader/Models/Enums/ItemRarity.cs
+++ b/src/FortniteReplayReader/Models/Enums/ItemRarity.cs
@@ -11,6 +11,7 @@ namespace FortniteReplayReader.Models.Enums
         MakeshiftAssaultRifle, MakeshiftSmg, MakeshiftShotgun, MakeshiftRevolver, MakeshiftBow,
         PrimalAssaultRifle, PrimalSmg, PrimalShotgun, PrimalRevolver, PrimalBow, StinkBow,
         FlameBow, MechBow, MechExplosiveBow, MetalBow,
-        Recycler, Shark, Raptor, Wolf
+        Recycler, Shark, Raptor, Wolf,
+        SlonePulseRifle, ReconScanner, RailGun, LlamaRoasterV3, KymeraRayGun, LeverShotgun
     };
 }

--- a/src/FortniteReplayReader/Models/KillFeedEntry.cs
+++ b/src/FortniteReplayReader/Models/KillFeedEntry.cs
@@ -222,6 +222,55 @@ namespace FortniteReplayReader.Models
                     case "Item.Weapon.Ranged.Shotgun.Swing.HighTier":
                         ItemType = ItemType.LeverShotgun;
                         break;
+                    case "Item.Weapon.Ranged.Pistol.Tracker":
+                        ItemType = ItemType.TrackerPistol;
+                        break;
+                    case "Item.Weapon.Ranged.Bow.Shockwave":
+                        ItemType = ItemType.ShockwaveBow;
+                        break;
+                    case "Item.Weapon.Ranged.Bow.Grappler":
+                        ItemType = ItemType.GrapplerBow;
+                        break;
+                    case "Gameplay.Damage.Elemental.Fire":
+                        ItemType = ItemType.Fire;
+                        break;
+                    case "Item.Weapon.Ranged.Shotgun.Dub":
+                        ItemType = ItemType.DubShotgun;
+                        break;
+                    case "Item.Weapon.Ranged.Launcher.Egg":
+                        ItemType = ItemType.EggLauncher;
+                        break;
+                    case "Gameplay.Damage.Physical.Explosive":
+                    case "EnvItem.ReactiveProp.PropaneTank":
+                        ItemType = ItemType.EnvironmentExplosion;
+                        break;
+                    case "Gameplay.Damage.Physical.Explosive.Gas":
+                    case "Item.Fuel.PetrolPickup":
+                        ItemType = ItemType.EnvironmentExplosiveGas;
+                        break;
+                    case "Item.Weapon.Vehicle.Meatball":
+                        ItemType = ItemType.Boat;
+                        break;
+                    case "Item.Weapon.Galileo.Lobster.Limo":
+                    case "Item.Weapon.Galileo.Lobster":
+                    case "Item.Weapon.Galileo.Lobster.Kayak":
+                        ItemType = ItemType.Lightsaber;
+                        break;
+                    case "Item.Weapon.Galileo.Bun":
+                        ItemType = ItemType.E11BlasterRifle;
+                        break;
+                    case "Building.Type.Prop":
+                    case "Building.Type.Container":
+                        ItemType = ItemType.BuildingProp;
+                        break;
+                    case "GameplayCue.Abilities.TractorBeam":
+                    case "Gameplay.Status.TractorBeam":
+                        ItemType = ItemType.Ufo;
+                        break;
+                    case "Ability.HighTower.Power.Date.ChainLightning":
+                    case "Ability.HighTower.Power.Date.BallLightning":
+                        ItemType = ItemType.Ability;
+                        break;
                     case "Gameplay.Effect.InstantDeath.Environment.UnderLandscape":
                         break;
                     case "Gameplay.Effect.InstantDeath.Environment":

--- a/src/FortniteReplayReader/Models/KillFeedEntry.cs
+++ b/src/FortniteReplayReader/Models/KillFeedEntry.cs
@@ -204,6 +204,24 @@ namespace FortniteReplayReader.Models
                     case "Pawn.Athena.NPC.Wildlife.Predator.Grandma":
                         ItemType = ItemType.Wolf;
                         break;
+                    case "Item.Weapon.Ranged.Assault.PastaRipper":
+                        ItemType = ItemType.SlonePulseRifle;
+                        break;
+                    case "Item.Weapon.Ranged.Scooter":
+                        ItemType = ItemType.ReconScanner;
+                        break;
+                    case "Item.Weapon.Ranged.Sniper.ReactorGrade":
+                        ItemType = ItemType.RailGun;
+                        break;
+                    case "Item.Weapon.Ranged.Assault.LlamaRoasterV3":
+                        ItemType = ItemType.KymeraRayGun;
+                        break;
+                    case "Item.Weapon.Ranged.Shotgun.Swing.LowTier":
+                        ItemType = ItemType.LeverShotgun;
+                        break;
+                    case "Item.Weapon.Ranged.Shotgun.Swing.HighTier":
+                        ItemType = ItemType.LeverShotgun;
+                        break;
                     case "Gameplay.Effect.InstantDeath.Environment.UnderLandscape":
                         break;
                     case "Gameplay.Effect.InstantDeath.Environment":


### PR DESCRIPTION
Added Item Types for the new weapons from the Invasion Season (C2S7) + the Lever-Action Shotgun.
The corresponding Death Tags are also added.
EDIT: Actually found a lot more missing ItemTypes and DeathTags (thanks to RazFridman/RazTracker)